### PR TITLE
Remove railtie_name from BPM::Railtie to prevent Rails deprecation notice

### DIFF
--- a/lib/bpm/railtie.rb
+++ b/lib/bpm/railtie.rb
@@ -1,7 +1,5 @@
 module BPM
   class Railtie < Rails::Railtie
-    railtie_name :bpm_rails
-
     config.preview_bpm_app = false
     config.bpm_app_dir = 'app'
 


### PR DESCRIPTION
Running a local Rails server for a project with bpm included in Gemfile, I kept getting this notice on server startup:

```
DEPRECATION WARNING: railtie_name is deprecated and has no effect. (called from require at /Users/floris/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.0.18/lib/bundler/runtime.rb:68)
```

I simply removed the line from the Railtie to prevent these notices from popping up. 

Setup details:
- rails 3.0.10
- ruby 1.9.2-p290
- bpm 1.0.0.rc.4
