### PR TITLE
Remove the no-longer-needed '--pre' suffix on gem install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ thing there.
 
 Install via RubyGems:
 
-  `gem install bpm --pre`
+  `gem install bpm`
 
 WARNING: Make sure you have the most recent version of RubyGems and the
 most recent version of RVM if you are using that.


### PR DESCRIPTION
It causes an old RC to be installed instead, which leads to errors trying to install certain packages.
