### PR TITLE
fixes #84 "invalid byte sequence in UTF-8"

### DIFF
--- a/lib/bpm/pipeline/generated_asset.rb
+++ b/lib/bpm/pipeline/generated_asset.rb
@@ -87,6 +87,9 @@ module BPM
           DATA = #{data.to_json};
         end_eval
 
+        ic = Iconv.new('UTF-8//IGNORE', 'UTF-8')
+        plugin_ctx = ic.iconv(plugin_ctx)
+
         ctx = BPM.compile_js(plugin_ctx);
         data = ctx.eval("BPM_PLUGIN.minify(DATA, CTX)")
 


### PR DESCRIPTION
by running "bpm init" an "invalid byte sequence in UTF-8 (ArgumentError)"
error happened which this one fixes it
