### PR TITLE
Adds ability to use BPM as a proxy

### DIFF
--- a/lib/bpm.rb
+++ b/lib/bpm.rb
@@ -16,6 +16,7 @@ module BPM
   autoload :Project,              'bpm/project'
   autoload :PackageProject,       'bpm/package_project'
   autoload :Rack,                 'bpm/rack'
+  autoload :RackProxy,            'bpm/rack_proxy'
   autoload :Server,               'bpm/server'
   autoload :Pipeline,             'bpm/pipeline'
   autoload :DirectiveProcessor,   'bpm/pipeline/directive_processor'

--- a/lib/bpm/package.rb
+++ b/lib/bpm/package.rb
@@ -24,7 +24,7 @@ module BPM
       "bpm:build"         => :hash,
       "bpm:use:transport" => :string,
       "bpm:provides"      => :hash,
-      "preview_proxy"     => :hash
+      "bpm:preview_proxy"        => :hash
     }
 
     PLUGIN_TYPES = %w[minifier]

--- a/lib/bpm/package.rb
+++ b/lib/bpm/package.rb
@@ -23,7 +23,8 @@ module BPM
       "dependencies:development" => :hash,
       "bpm:build"         => :hash,
       "bpm:use:transport" => :string,
-      "bpm:provides"      => :hash
+      "bpm:provides"      => :hash,
+      "preview_proxy"     => :hash
     }
 
     PLUGIN_TYPES = %w[minifier]

--- a/lib/bpm/rack_proxy.rb
+++ b/lib/bpm/rack_proxy.rb
@@ -6,26 +6,42 @@ module BPM
       mode = opts[:mode] || :debug
 
       @app = app
-      @proxy = project.preview_proxy
+      @proxy = project.bpm_preview_proxy
     end
 
     def call(env)
-      if env["PATH_INFO"] =~ /^\/#{@proxy['path']}/
-        # puts @app.inspect
-        request = ::Rack::Request.new(env)
+      req = ::Rack::Request.new(env)
+      method = req.request_method.downcase
+      method[0..0] = method[0..0].upcase
 
-        port = @proxy['port'] || (@proxy['use_ssl'] ? 443 : 80)
-        
-        http = Net::HTTP.new(@proxy['server'], port)
-        http.use_ssl = @proxy['use_ssl'] || false
-        
-        @response = http.start { |http|
-          path = "#{env["REQUEST_PATH"]}?#{env["QUERY_STRING"]}"
-          req = ::Net::HTTP::Get.new(path)
-          http.request(req)        
-        }
+      if req.path =~ %r{^#{@proxy['path']}} 
+        uri = URI.parse("#{req.scheme}://#{@proxy['host']}#{ ':'+@proxy['port'].to_s if @proxy['port']}#{req.path}")
 
-        [@response.code, {"Content-Type" => @response.content_type}, [@response.body]]  
+        proxy_request = Net::HTTP.const_get(method).new("#{uri.path}#{'?' if uri.query}#{uri.query}")
+
+        if proxy_request.request_body_permitted? and req.body
+          proxy_request.body_stream = req.body
+          proxy_request.content_length = req.content_length
+          proxy_request.content_type = req.content_type
+        end
+
+        proxy_request['X-Forwarded-For'] = (req.env['X-Forwarded-For'].to_s.split(/, +/) + [req.env['REMOTE_ADDR']]).join(", ")
+        proxy_request['X-Requested-With'] = req.env['HTTP_X_REQUESTED_WITH'] if req.env['HTTP_X_REQUESTED_WITH']
+        proxy_request['Accept-Encoding'] = req.accept_encoding
+        proxy_request['Cookie'] = req.env['HTTP_COOKIE']
+        proxy_request['Referer'] = req.referer
+        proxy_request.basic_auth *uri.userinfo.split(':') if (uri.userinfo && uri.userinfo.index(':'))
+
+        proxy_response = Net::HTTP.start(uri.host, uri.port, :use_ssl => @proxy['use_ssl'] || false) do |http|
+          http.request(proxy_request)
+        end
+
+        headers = {}
+        proxy_response.each_header do |k,v|
+          headers[k] = v unless k.to_s =~ /content-length|transfer-encoding/i
+        end
+
+        [proxy_response.code.to_i, headers, [proxy_response.read_body]]
       else
         @app.call(env)
       end

--- a/lib/bpm/rack_proxy.rb
+++ b/lib/bpm/rack_proxy.rb
@@ -1,0 +1,34 @@
+require 'net/http'
+
+module BPM
+  class RackProxy
+    def initialize(app, project, opts={})
+      mode = opts[:mode] || :debug
+
+      @app = app
+      @proxy = project.preview_proxy
+    end
+
+    def call(env)
+      if env["PATH_INFO"] =~ /^\/#{@proxy['path']}/
+        # puts @app.inspect
+        request = ::Rack::Request.new(env)
+
+        port = @proxy['port'] || (@proxy['use_ssl'] ? 443 : 80)
+        
+        http = Net::HTTP.new(@proxy['server'], port)
+        http.use_ssl = @proxy['use_ssl'] || false
+        
+        @response = http.start { |http|
+          path = "#{env["REQUEST_PATH"]}?#{env["QUERY_STRING"]}"
+          req = ::Net::HTTP::Get.new(path)
+          http.request(req)        
+        }
+
+        [@response.code, {"Content-Type" => @response.content_type}, [@response.body]]  
+      else
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/bpm/server.rb
+++ b/lib/bpm/server.rb
@@ -32,7 +32,7 @@ module BPM
       cur_mode    = @mode
 
       @app ||= ::Rack::Builder.new do
-        (use BPM::RackProxy, cur_project, :mode => cur_mode) unless cur_project.preview_proxy.empty?
+        (use BPM::RackProxy, cur_project, :mode => cur_mode) unless cur_project.bpm_preview_proxy.empty?
         use BPM::Rack, cur_project, :mode => cur_mode
         run ::Rack::Directory.new cur_project.root_path
       end.to_app

--- a/lib/bpm/server.rb
+++ b/lib/bpm/server.rb
@@ -32,6 +32,7 @@ module BPM
       cur_mode    = @mode
 
       @app ||= ::Rack::Builder.new do
+        (use BPM::RackProxy, cur_project, :mode => cur_mode) unless cur_project.preview_proxy.empty?
         use BPM::Rack, cur_project, :mode => cur_mode
         run ::Rack::Directory.new cur_project.root_path
       end.to_app


### PR DESCRIPTION
What's it do:
- supports all HTTP methods
- supports ssl
- supports Cookie'd sessions

How to use it?

Add this to your project.json:

<pre>
{
...
"bpm:preview_proxy": {
  "path": "/api",
  "host": "localhost",
  "port": 3000,
  "use_ssl": false
}
</pre>


path: requests that match this will be proxied
host/port: where to send the matched requests
use_ssl: defaults to false, is optional

Shout-outs to chrishyle and cwninja
